### PR TITLE
Fix AI Forced Movement to Free Attack loop bug

### DIFF
--- a/src/simulation/combatants/actions/playerActions.ts
+++ b/src/simulation/combatants/actions/playerActions.ts
@@ -49,7 +49,7 @@ export const Shotgun = new Action(
         .filter((zone: number) => {
           return zone !== newActor.zone;
         });
-      let pushZone = ai.FindBestMoveAmong(state, newTarget, pushableZones);
+      let pushZone = ai.FindBestMoveAmong(state, newTarget, pushableZones, true);
       if (pushZone !== null) newTarget.zone = pushZone;
 
       newTarget.isSuppressed = true;

--- a/src/simulation/combatants/ai/ai.ts
+++ b/src/simulation/combatants/ai/ai.ts
@@ -25,7 +25,8 @@ export class AI {
   FindBestMoveAmong(
     initialState: CombatState,
     combatant: Combatant,
-    zones: number[]
+    zones: number[],
+    isForced: boolean = false
   ): number | null {
     let bestMove: number | null = null;
     let bestScore: number = this.score(initialState);
@@ -35,7 +36,8 @@ export class AI {
         combatant,
         zoneDest,
         ExpectedValueForBoostAndModifier,
-        this
+        this,
+        isForced
       );
       let expectedValue = this.score(expectedState);
       if (expectedValue > bestScore) {

--- a/src/simulation/simulator.ts
+++ b/src/simulation/simulator.ts
@@ -70,10 +70,13 @@ function SimulateTurn(
       let action = bestActionAndTarget.action;
       let target = bestActionAndTarget.target;
       state = Act(state, combatant, action, target, RollDice, ai);
-    } else {
+    }
+    else {
+      // move as an action
       let bestMove = ai.FindBestMove(state, combatant);
-      if (bestMove !== null)
+      if (bestMove !== null) {
         state = Move(state, combatant, bestMove, RollDice, ai);
+      }
     }
     let newCombatant = state.GetCombatant(combatant);
     newCombatant.actionsTaken++;
@@ -109,27 +112,30 @@ export function Move(
   actor: Combatant,
   zoneDest: number,
   checkEvaluator: (modifier: number, boost: number) => number,
-  ai: AI
+  ai: AI,
+  isForced: boolean = false
 ): CombatState {
   let state = initialState.clone();
   let newActor = state.GetCombatant(actor);
-  let freeAttackers = newActor.isPlayer() ? state.enemies : state.players;
-  // Filter to living, non-suppressed enemies in the same zone, with a weapon that can target
-  freeAttackers = freeAttackers.filter((attacker) => {
-    let weapon = attacker.actions[0];
-    return (
-      !attacker.isDead() &&
-      attacker.zone === newActor.zone &&
-      !attacker.isSuppressed &&
-      weapon.minRange === 0
-    );
-  });
-  // Execute attacks
-  freeAttackers.forEach((freeAttacker) => {
-    let weapon = freeAttacker.actions[0];
-    state = Act(state, freeAttacker, weapon, newActor, checkEvaluator, ai);
-    newActor = state.GetCombatant(newActor);
-  });
+  if(!isForced) {
+    let freeAttackers = newActor.isPlayer() ? state.enemies : state.players;
+    // Filter to living, non-suppressed enemies in the same zone, with a weapon that can target
+    freeAttackers = freeAttackers.filter((attacker) => {
+      let weapon = attacker.actions[0];
+      return (
+        !attacker.isDead() &&
+        attacker.zone === newActor.zone &&
+        !attacker.isSuppressed &&
+        weapon.minRange === 0
+      );
+    });
+    // Execute attacks
+    freeAttackers.forEach((freeAttacker) => {
+      let weapon = freeAttacker.actions[0];
+      state = Act(state, freeAttacker, weapon, newActor, checkEvaluator, ai);
+      newActor = state.GetCombatant(newActor);
+    });
+  }
   newActor.zone = zoneDest;
   return state;
 }


### PR DESCRIPTION
Discovered a bug where a shotgun could trigger an AI loop, because the AI would predict a crit, which would force enemy movement, which would trigger a free attack from the same attacker, who would then predict a crit, etc.